### PR TITLE
When ignoring null skip also empty arrays

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,6 +3,7 @@ import { DEFAULT_SETTINGS, MetatableSettings, MetatableSettingTab } from './sett
 import { Context } from './core'
 import { RuleStore } from './rule'
 import metatable from './table'
+import isEmptyArray from './utils'
 import { taglist } from './mappers'
 // @ts-ignore
 import styles from './metatable.css'
@@ -25,7 +26,7 @@ function createMetatable(el: HTMLElement, data: object, context: Context) {
 function isEmpty(data: object, ignoredKeys: string[]): boolean {
   return Object.entries(data)
     .filter(([key, value]) => !(ignoredKeys.some(x => x == key)))
-    .every(([_, value]) => value == null)
+    .every(([_, value]) => value == null || isEmptyArray(value))
 }
 
 async function frontmatterProcessor(this: MetatablePlugin, el: HTMLElement, ctx: MarkdownPostProcessorContext): Promise<void> {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import { DEFAULT_SETTINGS, MetatableSettings, MetatableSettingTab } from './sett
 import { Context } from './core'
 import { RuleStore } from './rule'
 import metatable from './table'
-import isEmptyArray from './utils'
+import { isEmptyArray } from './utils'
 import { taglist } from './mappers'
 // @ts-ignore
 import styles from './metatable.css'

--- a/src/table.ts
+++ b/src/table.ts
@@ -3,6 +3,8 @@ import { taglist } from './mappers'
 import { Rule, RuleStore } from './rule'
 import { Leaf, Context, Settings } from './core'
 
+import isEmptyArray from './utils'
+
 function toggle(trigger: HTMLElement) {
   const isExpanded = trigger.getAttribute('aria-expanded') == 'true'
   trigger.setAttribute('aria-expanded', String(!isExpanded))
@@ -250,7 +252,7 @@ function set(data: object, context: Context): HTMLElement {
   root.classList.add('set')
 
   Object.entries(data).forEach(([label, value]: [string, unknown]) => {
-    if (ignoreNulls && value == null) return;
+    if (ignoreNulls && (value == null || isEmptyArray(value))) return;
     if (ignoredKeys.some(key => key == label)) return;
 
     root.append(member(label, value, valueContext))

--- a/src/table.ts
+++ b/src/table.ts
@@ -3,7 +3,7 @@ import { taglist } from './mappers'
 import { Rule, RuleStore } from './rule'
 import { Leaf, Context, Settings } from './core'
 
-import isEmptyArray from './utils'
+import { isEmptyArray } from './utils'
 
 function toggle(trigger: HTMLElement) {
   const isExpanded = trigger.getAttribute('aria-expanded') == 'true'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-export default function isEmptyArray(value: unknown): boolean {
+export function isEmptyArray(value: unknown): boolean {
   if (typeof value === 'string' {
     return value === '[]'
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export default function isEmptyArray(value: unknown): boolean {
+  if (typeof value === 'string' {
+    return value === '[]'
+  }
+
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Hi! Good plugin!

I thought if we don't want see a null values we also won't want see empty arrays.

For example, now I have YAML like this:

```
---
tags: [category]
aliases: []
created: '23.05.2021 22:20'
---
```

and see:

![image](https://user-images.githubusercontent.com/13031058/119793362-30c2f680-bedf-11eb-9304-8b33bc6976ed.png)

or (if expanded)

![image](https://user-images.githubusercontent.com/13031058/119793425-3fa9a900-bedf-11eb-85ea-9ecba255293c.png)

After fix we will ignore fields like this.