### PR TITLE
feat: Add zotero links

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Any value in the `tags` key is linked as a tag. Mimics the default Obsidian beha
 
 Any value that is a valid Obsidian URL such as `obsidian://open?vault=my_vault&file=my_file`.
 
+#### Zotero
+
+Any Zotero URI such as `zotero://select/items/@citekey`. Link becomes click-able and selects the item in Zotero (also allows for opening PDF attachments of items via `zotero://open-pdf/...` ). Requires [Zotero](https://www.zotero.org/) to be installed. If used with [obsidian-citation-plugin](https://github.com/hans/obsidian-citation-plugin), the variable `{{zoteroSelectURI}}` can be used in the frontmatter to create a click-able link to open the linked citation in Zotero directly from the metatable.
 
 #### Local
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -138,7 +138,7 @@ function isObsidianUrl(url: URL | string): boolean {
 }
 
 function isUrl(url: URL | string): boolean {
-  const allowedProtocols = ['http:', 'https:', 'evernote:']
+  const allowedProtocols = ['http:', 'https:', 'evernote:', 'zotero:']
 
   return (url instanceof URL && allowedProtocols.some(protocol => url.protocol == protocol))
 }


### PR DESCRIPTION
Addition of recognizing zotero links to open linked bibliography entries. Works with {{zoteroSelectURI}} from obsidian-citation-plugin