### PR TITLE
Better support for unicode tags

### DIFF
--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -3,8 +3,7 @@ import { useMixture } from "src/mixture"
 
 export function Tag(props: any) {
   const { openTag } = useMixture()
-  const safeValue = encodeURI(props.value)
-  const url = `#${safeValue}`
+  const url = `#${props.value}`
   const clickHandler = (event: any) => {
     const trigger: HTMLElement = event.target
 


### PR DESCRIPTION
Currently, the plugin encodes the non-latin tags when click them to search, such as: `tag:#우유` -> `tag:#%EC%9A%B0%EC%9C%A0`. (Another example: #36 ) It is not the way Obsidian treats tags, so searching functionality do not work properly. I think removing `encodeURI` to let tag text unchanged might be more appropriate.